### PR TITLE
Added support for ruby 2.3 version

### DIFF
--- a/config/nagira.init_d
+++ b/config/nagira.init_d
@@ -55,7 +55,7 @@ NAGIRA_LOG=${NAGIRA_LOG:-/var/log/nagios/nagira.log}
 export RACK_ENV NAGIRA_LOG NAGIRA_USER RVM_STRING
 
 get_pid () {
-  echo $(ps -C nagira,ruby,ruby1.9.1,ruby1.9.3,ruby2.0,ruby2.1,ruby2.2 -o pid,cmd | \
+  echo $(ps -C nagira,ruby,ruby1.9.1,ruby1.9.3,ruby2.0,ruby2.1,ruby2.2,ruby2.3 -o pid,cmd | \
             awk '$0 ~ /bin\/nagira *$/ {print $1}')
 }
 


### PR DESCRIPTION
Quick fix in init.d script to make it work with 2.3 ruby version. The permanent fix would be to make it as erb template and parameterize the ruby version.  The other way around could be checking the current ruby version and if that is not included in the list then append as well.